### PR TITLE
Add instructions to run locally in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,4 @@
 ## Run locally
 ### Setup
 Install [Docker](https://docs.docker.com/install/linux/docker-ce/ubuntu/) and [Docker compose](https://docs.docker.com/compose/install/).
-In the project root folder run ```docker-compose up --build```, to build and spinn up application containers. Run ```docker-compose down``` to stop them. The build flag is only nessecary the first time, check out the (docker-compose documentation)[https://docs.docker.com/compose/] for more details.
+In the project root folder run ```docker-compose up --build```, to build and spin up application containers. Run ```docker-compose down``` to stop them. The build flag is only necessary the first time, check out the (docker-compose documentation)[https://docs.docker.com/compose/] for more details.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,6 @@
 # GrowBud
+
+## Run locally
+### Setup
+Install [Docker](https://docs.docker.com/install/linux/docker-ce/ubuntu/) and [Docker compose](https://docs.docker.com/compose/install/).
+In the project root folder run ```docker-compose up --build```, to build and spinn up application containers. Run ```docker-compose down``` to stop them. The build flag is only nessecary the first time, check out the (docker-compose documentation)[https://docs.docker.com/compose/] for more details.


### PR DESCRIPTION
Added instructions for installing docker and docker compose to help
new comers get started. Docker compose allows for easy setup of a dev
environment and in the future we can use it for end to end testing.