### PR TITLE
Add PROJECT_PATH env to firebase deploy job

### DIFF
--- a/.github/workflows/client-deploy.yml
+++ b/.github/workflows/client-deploy.yml
@@ -45,3 +45,5 @@ jobs:
           args: deploy --only hosting:prod
         env:
           FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
+          PROJECT_PATH: ./client
+          PROJECT_ID: "growbud-50ed4"


### PR DESCRIPTION
*Description*

As per documentation https://github.com/marketplace/actions/github-action-for-firebase
PROJECT_PATH must be added as env if firebase.json is not in root and i dont think it is in root of repo since its under /client/firebase.json

*How to test?*

MERGE AND PRAY
