### PR TITLE
Fix data-store installation procedure

### DIFF
--- a/server/data-store/Dockerfile
+++ b/server/data-store/Dockerfile
@@ -1,12 +1,13 @@
-FROM node:12
+FROM node:10
 
 WORKDIR /app
 
 COPY package*.json ./
-COPY src ./
+COPY src ./src
+COPY tsconfig.json ./
 
 RUN npm install
-RUN npm run tsc
+RUN npm run tsc-build
 
 EXPOSE 9090
 

--- a/server/data-store/package.json
+++ b/server/data-store/package.json
@@ -8,7 +8,8 @@
     "test": "echo \"Error: no test specified\" && exit 0",
     "standard": "./node_modules/standard/bin/cmd.js --fix",
     "tsc-watch": "./node_modules/typescript/bin/tsc -w",
-    "tsc": "./node_modules/typescript/bin/tsc "
+    "tsc": "./node_modules/typescript/bin/tsc ",
+    "tsc-build": "./node_modules/typescript/bin/tsc -p tsconfig.json"
   },
   "author": "",
   "license": "ISC",

--- a/server/data-store/tsconfig.json
+++ b/server/data-store/tsconfig.json
@@ -2,7 +2,7 @@
     "compilerOptions": {
         /* Basic Options */
         // "incremental": true,                   /* Enable incremental compilation */
-        "target": "ES2018", /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'. */
+        "target": "ESNEXT", /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'. */
         "module": "commonjs", /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
         // "lib": [],                             /* Specify library files to be included in the compilation. */
         // "allowJs": true,                       /* Allow javascript files to be compiled. */
@@ -13,7 +13,7 @@
         // "sourceMap": true,                     /* Generates corresponding '.map' file. */
         // "outFile": "./",                       /* Concatenate and emit output to single file. */
         "outDir": "./dist", /* Redirect output structure to the directory. */
-        // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
+        "rootDir": "./", /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
         // "composite": true,                     /* Enable project compilation */
         // "tsBuildInfoFile": "./",               /* Specify file to store incremental compilation information */
         // "removeComments": true,                /* Do not emit comments to output. */


### PR DESCRIPTION


*Description*
During the setup npm install would fail because of two reasons:
- One the src folder couldn't be found.
- Two google cloud doesn't support node 12 and the libraries were not
installed properly.

*How to test?*
docker-compose up --build
go to [graphiql](http://localhost:9090/graph/view)
