### PR TITLE
Fix data-store deploy

### DIFF
--- a/.github/workflows/data-store-deploy.yml
+++ b/.github/workflows/data-store-deploy.yml
@@ -14,6 +14,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v1
+      - name: Install dependencies
+        run: |
+          cd server/data-store
+          npm install
+          npm run tsc-build
       - uses: actions-hub/gcloud@master
         env:
           PROJECT_ID: ${{secrets.GCLOUD_PROJECT_ID}}


### PR DESCRIPTION

*Description*
Updated the deploy action, we should build the project before pushing to google cloud else
it can't find the dist folder.


*How to test?*
Test next time we merge a feature to master.