### PR TITLE
Add Refreshtoken

### DIFF
--- a/server/data-store/src/lib/auth/index.ts
+++ b/server/data-store/src/lib/auth/index.ts
@@ -7,7 +7,8 @@ export interface Credential {
 
 export interface userInfo {
   JWT: string,
-  id: string
+  id: string,
+  refreshToken: string
 }
 
 interface firebaseError {
@@ -40,7 +41,8 @@ async function userDTO(user: any): Promise<userInfo> {
   const token = await user.getIdToken(true)
   return {
     JWT: token,
-    id: user.uid
+    id: user.uid,
+    refreshToken: user.refreshToken
   }
 }
 

--- a/server/data-store/src/schema/index.ts
+++ b/server/data-store/src/schema/index.ts
@@ -31,7 +31,8 @@ const JWT = new GraphQLObjectType({
     description: 'Login info',
     fields: () => ({
         JWT: nonNullGqlString,
-        id: nonNullGqlString
+        id: nonNullGqlString,
+        refreshToken: nonNullGqlString
     })
 })
 
@@ -42,7 +43,8 @@ const Registration = new GraphQLObjectType({
         JWT: nonNullGqlString,
         email: nonNullGqlString,
         userName: nonNullGqlString,
-        id: nonNullGqlString
+        id: nonNullGqlString,
+        refreshToken: nonNullGqlString
     })
 })
 
@@ -120,10 +122,11 @@ const mutationType = new GraphQLObjectType({
                 password: nonNullGqlString
             },
             resolve: async (_root, args) => {
-                const { JWT, id }: userInfo = await login(args as Credential)
+                const { JWT, id, refreshToken }: userInfo = await login(args as Credential)
                 return {
                     JWT,
-                    id
+                    id,
+                    refreshToken
                 }
             }
         },
@@ -137,10 +140,11 @@ const mutationType = new GraphQLObjectType({
             },
             resolve: async (_root, args) => {
                 const cred: Credential = { email: args.email, password: args.password }
-                const { JWT, id }: userInfo = await registerCredentials(cred)
+                const { JWT, id, refreshToken }: userInfo = await registerCredentials(cred)
                 return {
                     JWT,
                     id,
+                    refreshToken,
                     email: args.email,
                     userName: args.userName
                 }

--- a/server/data-store/src/schema/index.ts
+++ b/server/data-store/src/schema/index.ts
@@ -31,8 +31,8 @@ const JWT = new GraphQLObjectType({
     description: 'Login info',
     fields: () => ({
         JWT: nonNullGqlString,
+        JWTExpiry: nonNullGqlString,
         id: nonNullGqlString,
-        refreshToken: nonNullGqlString
     })
 })
 
@@ -41,10 +41,10 @@ const Registration = new GraphQLObjectType({
     description: 'Registration details',
     fields: () => ({
         JWT: nonNullGqlString,
+        JWTExpiry: nonNullGqlString,
         email: nonNullGqlString,
         userName: nonNullGqlString,
         id: nonNullGqlString,
-        refreshToken: nonNullGqlString
     })
 })
 
@@ -121,12 +121,16 @@ const mutationType = new GraphQLObjectType({
                 email: nonNullGqlString,
                 password: nonNullGqlString
             },
-            resolve: async (_root, args) => {
-                const { JWT, id, refreshToken }: userInfo = await login(args as Credential)
+            resolve: async (_root, args, context) => {
+                const { JWT, JWTExpiry, id, refreshToken }: userInfo = await login(args as Credential)
+                // Modify the response object
+                context.res.cookie('refreshToken', refreshToken, {
+                    httpOnly: true
+                })
                 return {
                     JWT,
-                    id,
-                    refreshToken
+                    JWTExpiry,
+                    id
                 }
             }
         },
@@ -138,13 +142,17 @@ const mutationType = new GraphQLObjectType({
                 password: nonNullGqlString,
                 userName: nonNullGqlString,
             },
-            resolve: async (_root, args) => {
+            resolve: async (_root, args, context) => {
                 const cred: Credential = { email: args.email, password: args.password }
-                const { JWT, id, refreshToken }: userInfo = await registerCredentials(cred)
+                const { JWT, JWTExpiry, id, refreshToken }: userInfo = await registerCredentials(cred)
+                // Modify the response object
+                context.res.cookie('refreshToken', refreshToken, {
+                    httpOnly: true
+                })
                 return {
                     JWT,
+                    JWTExpiry,
                     id,
-                    refreshToken,
                     email: args.email,
                     userName: args.userName
                 }


### PR DESCRIPTION
*Description*
Return a refresh token on registration and login. This is needed if we want to keep tokens alive without the user to have to login again.

*How to test?*
Spin up the server and test write a mutation in graphqil like the one below.
mutation{
  login(email:"e@mail", password:"somepw") {
    JWT,
    id,
    refreshToken
  }
}