### PR TITLE
remove volumes: to fix server build step

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,6 @@ services:
       context: ./server/data-store
     ports:
       - "9090:9090"
-    volumes:
-      - "./server/data-store/:/app"
 
   growbud_client:
     container_name: growbud_client


### PR DESCRIPTION
*Description*

remove "volumes:" from docker-compose.yml to fix issue with typescript dist build being overwritten by local files.

*How to test?*

Run docker-compose up --build and check that server fires up
