### PR TITLE
Fix refreshroute not parsing cookie

### DIFF
--- a/server/data-store/package-lock.json
+++ b/server/data-store/package-lock.json
@@ -788,6 +788,22 @@
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
       "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg=="
     },
+    "cookie-parser": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.4.tgz",
+      "integrity": "sha512-lo13tqF3JEtFO7FyA49CqbhaFkskRJ0u/UAiINgrIXeRCY41c88/zxtrECl8AKH3B0hj9q10+h3Kt8I7KlW4tw==",
+      "requires": {
+        "cookie": "0.3.1",
+        "cookie-signature": "1.0.6"
+      },
+      "dependencies": {
+        "cookie": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
+          "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
+        }
+      }
+    },
     "cookie-signature": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",

--- a/server/data-store/package-lock.json
+++ b/server/data-store/package-lock.json
@@ -329,7 +329,6 @@
       "version": "1.17.1",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.17.1.tgz",
       "integrity": "sha512-RoX2EZjMiFMjZh9lmYrwgoP9RTpAjSHiJxdp4oidAQVO02T7HER3xj9UKue5534ULWeqVEkujhWcyvUce+d68w==",
-      "dev": true,
       "requires": {
         "@types/connect": "*",
         "@types/node": "*"
@@ -348,16 +347,22 @@
       "version": "3.4.32",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.32.tgz",
       "integrity": "sha512-4r8qa0quOvh7lGD0pre62CAb1oni1OO6ecJLGCezTmhQ8Fz50Arx9RUszryR8KlgK6avuSXvviL6yWyViQABOg==",
-      "dev": true,
       "requires": {
         "@types/node": "*"
+      }
+    },
+    "@types/cookie-parser": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@types/cookie-parser/-/cookie-parser-1.4.2.tgz",
+      "integrity": "sha512-uwcY8m6SDQqciHsqcKDGbo10GdasYsPCYkH3hVegj9qAah6pX5HivOnOuI3WYmyQMnOATV39zv/Ybs0bC/6iVg==",
+      "requires": {
+        "@types/express": "*"
       }
     },
     "@types/express": {
       "version": "4.17.1",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.1.tgz",
       "integrity": "sha512-VfH/XCP0QbQk5B5puLqTLEeFgR8lfCJHZJKkInZ9mkYd+u8byX0kztXEQxEk4wZXJs8HI+7km2ALXjn4YKcX9w==",
-      "dev": true,
       "requires": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "*",
@@ -368,7 +373,6 @@
       "version": "4.16.10",
       "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.16.10.tgz",
       "integrity": "sha512-gM6evDj0OvTILTRKilh9T5dTaGpv1oYiFcJAfgSejuMJgGJUsD9hKEU2lB4aiTNy4WwChxRnjfYFuBQsULzsJw==",
-      "dev": true,
       "requires": {
         "@types/node": "*",
         "@types/range-parser": "*"
@@ -382,8 +386,7 @@
     "@types/mime": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.1.tgz",
-      "integrity": "sha512-FwI9gX75FgVBJ7ywgnq/P7tw+/o1GUbtP0KzbtusLigAOgIgNISRK0ZPl4qertvXSIE8YbsVJueQ90cDt9YYyw==",
-      "dev": true
+      "integrity": "sha512-FwI9gX75FgVBJ7ywgnq/P7tw+/o1GUbtP0KzbtusLigAOgIgNISRK0ZPl4qertvXSIE8YbsVJueQ90cDt9YYyw=="
     },
     "@types/node": {
       "version": "12.11.7",
@@ -407,14 +410,12 @@
     "@types/range-parser": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.3.tgz",
-      "integrity": "sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA==",
-      "dev": true
+      "integrity": "sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA=="
     },
     "@types/serve-static": {
       "version": "1.13.3",
       "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.3.tgz",
       "integrity": "sha512-oprSwp094zOglVrXdlo/4bAHtKTAxX6VT8FOZlBKrmyLbNvE1zxZyJ6yikMVtHIvwP45+ZQGJn+FdXGKTozq0g==",
-      "dev": true,
       "requires": {
         "@types/express-serve-static-core": "*",
         "@types/mime": "*"

--- a/server/data-store/package.json
+++ b/server/data-store/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "@google-cloud/firestore": "^2.5.0",
+    "@types/cookie-parser": "^1.4.2",
     "@types/qs": "^6.9.0",
     "@types/uuid": "^3.4.6",
     "axios": "^0.19.0",

--- a/server/data-store/package.json
+++ b/server/data-store/package.json
@@ -25,6 +25,7 @@
     "@types/qs": "^6.9.0",
     "@types/uuid": "^3.4.6",
     "axios": "^0.19.0",
+    "cookie-parser": "^1.4.4",
     "dotenv": "^8.2.0",
     "express": "^4.17.1",
     "express-graphql": "^0.9.0",

--- a/server/data-store/src/index.ts
+++ b/server/data-store/src/index.ts
@@ -3,10 +3,12 @@ import express from 'express'
 import graphQLHTTP from 'express-graphql'
 import schema from './schema'
 import { refreshToken as rf, RefreshInfo } from './lib/auth'
+import cookieParser from 'cookie-parser'
 const app = express()
 const port = process.env.PORT ? process.env.PORT : 9090
 
-app.use(express.json());
+app.use(express.json())
+app.use(cookieParser())
 app.use((_req, res, next) => {
   res.header('Access-Control-Allow-Origin', '*')
   res.header('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Accept')

--- a/server/data-store/src/index.ts
+++ b/server/data-store/src/index.ts
@@ -19,12 +19,17 @@ app.get('/', (_req, res) => {
 })
 
 app.post('/api/refreshToken', async (req, res) => {
-  const { JWT, JWTExpiry, refreshToken }: RefreshInfo = await rf(req.body.token)
+  const token = req?.cookies?.refreshToken
+  if (token === null || token === undefined) {
+    res.status(400).send({ error: 'missing payload' })
+  } else {
+    const { JWT, JWTExpiry, refreshToken }: RefreshInfo = await rf(token)
 
-  res.cookie('refreshToken', refreshToken, {
-    httpOnly: true
-  })
-  res.status(200).send({ JWT, JWTExpiry })
+    res.cookie('refreshToken', refreshToken, {
+      httpOnly: true
+    })
+    res.status(200).send({ JWT, JWTExpiry })
+  }
 })
 
 app.use('/graph/view', graphQLHTTP({

--- a/server/data-store/src/lib/auth/index.ts
+++ b/server/data-store/src/lib/auth/index.ts
@@ -74,7 +74,7 @@ export async function refreshToken(token: string): Promise<RefreshInfo> {
       refreshToken: data.refresh_token
     }
   } catch (error) {
-    console.error(error)
+    console.error(error.message)
     throw (new Error('Authentication error'))
 
   }


### PR DESCRIPTION
*Description*
The client can't extract a value from a HTTP only cookie thus the endpoint could never receive the refresh token. Now we parse the cookie sent by the client instead.
*How to test?*

1. Login as a user to receive refresh token cookie.
2. Make a refresh request and note the new token.
