### PR TITLE
Add function for removing watering schedule

### DIFF
--- a/server/data-store/src/lib/db/index.ts
+++ b/server/data-store/src/lib/db/index.ts
@@ -57,6 +57,16 @@ export async function scheduleWateringFor(plant: object, userId: string, timesta
     }
 }
 
+export async function removeWateringScheduleById(id: string) {
+    try {
+        await db.collection('wateringSchedules')
+            .doc(id)
+            .delete()
+    } catch (error) {
+        console.error(error)
+    }
+}
+
 function snapshotToSchedule(doc: firebase.firestore.QueryDocumentSnapshot | firebase.firestore.DocumentSnapshot): WateringSchedule {
     return Maybe.Just(doc.data()).matchWith({
         Just: (x: any) => ({

--- a/server/data-store/src/lib/db/index.ts
+++ b/server/data-store/src/lib/db/index.ts
@@ -57,14 +57,16 @@ export async function scheduleWateringFor(plant: object, userId: string, timesta
     }
 }
 
-export async function removeWateringScheduleById(id: string) {
+export async function removeWateringScheduleById(id: string): Promise<object> {
     try {
         await db.collection('wateringSchedules')
             .doc(id)
             .delete()
     } catch (error) {
         console.error(error)
+        return { status: false }
     }
+    return { status: true }
 }
 
 function snapshotToSchedule(doc: firebase.firestore.QueryDocumentSnapshot | firebase.firestore.DocumentSnapshot): WateringSchedule {

--- a/server/data-store/src/schema/index.ts
+++ b/server/data-store/src/schema/index.ts
@@ -18,7 +18,8 @@ import {
 import {
     getWateringSchedulesForUser,
     getWateringScheduleById,
-    scheduleWateringFor
+    scheduleWateringFor,
+    removeWateringScheduleById
 } from '../lib/db'
 
 const nonNullGqlString = { type: new GraphQLNonNull(GraphQLString) }
@@ -68,6 +69,11 @@ const Plant = new GraphQLObjectType({
         id: nonNullGqlString,
         name: nonNullGqlString,
     })
+})
+const Empty = new GraphQLObjectType({
+    name: "Empty",
+    description: "Empty return type",
+    fields: () => ({})
 })
 
 /**
@@ -178,6 +184,14 @@ const mutationType = new GraphQLObjectType({
                 interval
             },
             resolve: async (_root, args) => scheduleWateringFor(args.plant ?? {}, args.userId, args.timestamp, args.interval)
+        },
+        deleteWateringSchedule: {
+            description: "Remove a schedule",
+            type: Empty,
+            args: {
+                id: nonNullGqlString,
+            },
+            resolve: async (_root, args) => removeWateringScheduleById(args.id)
         }
     })
 })

--- a/server/data-store/src/schema/index.ts
+++ b/server/data-store/src/schema/index.ts
@@ -6,6 +6,7 @@ import {
     GraphQLNonNull,
     GraphQLInt,
     GraphQLList,
+    GraphQLBoolean
 } from 'graphql'
 
 import {
@@ -70,10 +71,12 @@ const Plant = new GraphQLObjectType({
         name: nonNullGqlString,
     })
 })
-const Empty = new GraphQLObjectType({
-    name: "Empty",
-    description: "Empty return type",
-    fields: () => ({})
+const Status = new GraphQLObjectType({
+    name: "Status",
+    description: "Status of operation, evaluates to True or False",
+    fields: () => ({
+        status: { type: GraphQLBoolean }
+    })
 })
 
 /**
@@ -187,7 +190,7 @@ const mutationType = new GraphQLObjectType({
         },
         deleteWateringSchedule: {
             description: "Remove a schedule",
-            type: Empty,
+            type: Status,
             args: {
                 id: nonNullGqlString,
             },


### PR DESCRIPTION
*Description*

A user should be able to remove a schedule. This pr introduces a function to remove a schedule by Id.

*How to test?*

1. Create a schedule and not the Id
2. Remove it  by calling removeWateringScheduleById with the Id from previous request.
