### PR TITLE
Refactor registration flow

### DIFF
--- a/server/data-store/src/lib/auth/index.ts
+++ b/server/data-store/src/lib/auth/index.ts
@@ -50,7 +50,7 @@ export async function login(credential: Credential): Promise<userInfo> {
   }
 }
 
-export async function registerUser(credential: Credential, userName: string): Promise<userInfo> {
+export async function registerUser(credential: Credential, userName: string): Promise<boolean> {
   try {
     const uid = uuidv4()
     await admin.auth().createUser({
@@ -61,7 +61,7 @@ export async function registerUser(credential: Credential, userName: string): Pr
       password: credential.password,
       disabled: false
     })
-    return login(credential)
+    return true
   } catch (error) {
     console.error('Unable to register credentials: ', error)
     throw (new Error('Authentication error'))

--- a/server/data-store/src/schema/index.ts
+++ b/server/data-store/src/schema/index.ts
@@ -156,7 +156,8 @@ const mutationType = new GraphQLObjectType({
             },
             resolve: async (_root, args, context) => {
                 const cred: Credential = { email: args.email, password: args.password }
-                const { JWT, JWTExpiry, id, refreshToken }: userInfo = await registerUser(cred, args.userName)
+                await registerUser(cred, args.username)
+                const { JWT, JWTExpiry, id, refreshToken }: userInfo = await login(cred)
                 // Modify the response object
                 context.res.cookie('refreshToken', refreshToken, {
                     httpOnly: true


### PR DESCRIPTION


## **Description**
Call the login function explicitly after registering the user. It's easier to reason about if the function calls aren't nested.

## **How to test?**
Register a user and you should receive a JWT and refresh token cookie as normal.
