### PR TITLE
Feature/schedule for multiple plants

### DIFF
--- a/server/data-store/src/lib/db/index.ts
+++ b/server/data-store/src/lib/db/index.ts
@@ -5,7 +5,7 @@ import Maybe from 'folktale/maybe'
 
 export interface WateringSchedule {
     id: string,
-    plant: object,
+    plants: Array<object>,
     nextTimeToWater: string,
     interval: number
 }
@@ -38,11 +38,11 @@ export async function getWateringScheduleById(id: string): Promise<WateringSched
     return snapshotToSchedule(doc)
 }
 
-export async function scheduleWateringFor(plant: object, userId: string, timestamp: string, interval: number): Promise<WateringSchedule> {
+export async function scheduleWateringFor(plants: Array<object>, userId: string, timestamp: string, interval: number): Promise<WateringSchedule> {
     const uuid: string = uuidv4()
     const schedule = {
         userId,
-        plant,
+        plants,
         nextTimeToWater: timestamp,
         interval
     }

--- a/server/data-store/src/schema/index.ts
+++ b/server/data-store/src/schema/index.ts
@@ -58,7 +58,7 @@ const WateringSchedule = new GraphQLObjectType({
     fields: () => ({
         id: nonNullGqlString,
         userId: nonNullGqlString,
-        plant: { type: GraphQLList(Plant) },
+        plants: { type: GraphQLList(Plant) },
         nextTimeToWater: nonNullGqlString,
         interval
     })
@@ -196,7 +196,7 @@ const mutationType = new GraphQLObjectType({
                 timestamp: nonNullGqlString,
                 interval
             },
-            resolve: async (_root, args) => scheduleWateringFor(args.plant ?? {}, args.userId, args.timestamp, args.interval)
+            resolve: async (_root, args) => scheduleWateringFor(args.plants ?? [], args.userId, args.timestamp, args.interval)
         },
         deleteWateringSchedule: {
             description: "Remove a schedule",

--- a/server/data-store/src/schema/index.ts
+++ b/server/data-store/src/schema/index.ts
@@ -6,7 +6,7 @@ import {
     GraphQLNonNull,
     GraphQLInt,
     GraphQLList,
-    GraphQLBoolean
+    GraphQLBoolean,
 } from 'graphql'
 
 import {
@@ -58,7 +58,7 @@ const WateringSchedule = new GraphQLObjectType({
     fields: () => ({
         id: nonNullGqlString,
         userId: nonNullGqlString,
-        plant: { type: Plant },
+        plant: { type: GraphQLList(Plant) },
         nextTimeToWater: nonNullGqlString,
         interval
     })
@@ -68,7 +68,7 @@ const Plant = new GraphQLObjectType({
     name: "Plant",
     description: "Information about a plant.",
     fields: () => ({
-        id: nonNullGqlString,
+        id: { type: GraphQLString, description: 'uuid of the Plant' },
         name: nonNullGqlString,
     })
 })
@@ -183,14 +183,14 @@ const mutationType = new GraphQLObjectType({
             description: "Set up a reminder for when to water a plant next.",
             type: WateringSchedule,
             args: {
-                plant: {
-                    type: new GraphQLInputObjectType({
+                plants: {
+                    type: GraphQLList(new GraphQLInputObjectType({
                         name: 'plantInput',
                         fields: {
-                            id: nonNullGqlString,
+                            id: { type: GraphQLString, description: 'uuid of the Plant' },
                             name: nonNullGqlString,
                         }
-                    })
+                    }))
                 },
                 userId: nonNullGqlString,
                 timestamp: nonNullGqlString,


### PR DESCRIPTION
## **Description**

Watering schedule mutation accepts a list of plants. Also made id optional untill we have propper support for plants.

## **How to test?**
Go to graph/view and make a request such as: "mutation {
  nextWateringDateFor(plants: [{name:"p1"}, {name:"asdd"}],userId:"dasd", timestamp: "123", interval: 2333) {
    id,
    plants {
      name
    }
  }
}"

And not the schedule in the db.
