### PR TITLE
Update where whitelist config is read from

### DIFF
--- a/server/data-store/app.yaml
+++ b/server/data-store/app.yaml
@@ -2,3 +2,4 @@ runtime: nodejs12
 
 env_variables:
   FIREBASEAPIKEY: "fbapikey"
+  WHITELIST: "https://growbud-50ed4.web.app,https://growbud-50ed4.firebaseapp.com"

--- a/server/data-store/src/.env.example
+++ b/server/data-store/src/.env.example
@@ -1,0 +1,4 @@
+NODE_ENV=development
+FIREBASEAPIKEY=your key
+GOOGLE_APPLICATION_CREDENTIALS=path to service acc
+WHITELIST=http://localhost:8080

--- a/server/data-store/src/index.ts
+++ b/server/data-store/src/index.ts
@@ -6,7 +6,7 @@ import { refreshToken as rf, RefreshInfo } from './lib/auth'
 import cookieParser from 'cookie-parser'
 const app = express()
 const port = process.env.PORT ? process.env.PORT : 9090
-const whitelist = process.env.NODE_ENV === 'development' ? 'http://localhost:8080' : '*'
+const whitelist = process.env.WHITELIST
 
 app.use(express.json())
 app.use(cookieParser())


### PR DESCRIPTION
## **Description**
Read whitelist from process.env, for local dev it's set in the .env file for prod in app.yml

## **How to test?**
Docker-compose up --build. Should work as normal for dev. For prod firebase and gcp needs to be deployd from commandline.
