### PR TITLE
Add graphql mutation for updating existing schedule.

### DIFF
--- a/server/data-store/src/lib/db/index.ts
+++ b/server/data-store/src/lib/db/index.ts
@@ -56,6 +56,23 @@ export async function scheduleWateringFor(plants: Array<object>, userId: string,
     }
 }
 
+export async function updateWateringSchedule(scheduleId: string, plants: Array<object>, userId: string, timestamp: string, interval: number): Promise<WateringSchedule> {
+    const schedule = {
+        userId,
+        plants,
+        nextTimeToWater: timestamp,
+        interval
+    }
+
+    await db.collection('wateringSchedules')
+        .doc(scheduleId)
+        .set({ schedule }, { merge: true })
+    return {
+        id: scheduleId,
+        ...schedule
+    }
+}
+
 export async function removeWateringScheduleById(id: string): Promise<object> {
     try {
         await db.collection('wateringSchedules')


### PR DESCRIPTION
## **Description**
Add graphql mutation for updating existing schedule.

## **How to test?**

Create a new schedule with:
mutation {
  nextWateringDateFor(plants: [{name:"p1"}, {name:"asdd"}],userId:"hh", timestamp: "123", interval: 2333) {
    id,
    plants {
      name
    }
  }
}

and update with:
mutation {
  updateWateringSchedule(scheduleId:"Id", plants: [{name:"plant"}],userId:"hh", timestamp: "123", interval: 2333) {
    id,
    plants {
      name
    }
  }
}
