### PR TITLE
Remove userId from gql functions

### DIFF
--- a/client/src/api/wateringschedule/index.js
+++ b/client/src/api/wateringschedule/index.js
@@ -1,17 +1,17 @@
 import gql from 'graphql-tag';
 
 export const ADD_WATERINGSCHEDULE = gql`
-    mutation ($plants: [plantInput], $userId: String!, $timestamp: String!, $interval: Int!){
-        nextWateringDateFor(plants: $plants, timestamp: $timestamp, interval: $interval  ) {
+    mutation ($plants: [plantInput], $timestamp: String!, $interval: Int!){
+        nextWateringDateFor(plants: $plants, timestamp: $timestamp, interval: $interval) {
             id
-            plants{name}
+            plants{ name }
             nextTimeToWater
         }
     }
 `
 
 export const GET_MY_WATERINGSCHEDULES = gql`
-    query ($userId: String!){
+    query {
         wateringScheduleForUser {
             id
             plants { name }

--- a/client/src/api/wateringschedule/index.js
+++ b/client/src/api/wateringschedule/index.js
@@ -1,8 +1,8 @@
 import gql from 'graphql-tag';
 
-export const ADD_WATERINGSCHEDULE = gql `
+export const ADD_WATERINGSCHEDULE = gql`
     mutation ($plants: [plantInput], $userId: String!, $timestamp: String!, $interval: Int!){
-        nextWateringDateFor(plants: $plants, userId: $userId, timestamp: $timestamp, interval: $interval  ) {
+        nextWateringDateFor(plants: $plants, timestamp: $timestamp, interval: $interval  ) {
             id
             plants{name}
             nextTimeToWater
@@ -10,9 +10,9 @@ export const ADD_WATERINGSCHEDULE = gql `
     }
 `
 
-export const GET_MY_WATERINGSCHEDULES = gql `
+export const GET_MY_WATERINGSCHEDULES = gql`
     query ($userId: String!){
-        wateringScheduleForUser(userId: $userId) {
+        wateringScheduleForUser {
             id
             plants { name }
             nextTimeToWater
@@ -21,9 +21,9 @@ export const GET_MY_WATERINGSCHEDULES = gql `
     }
 `
 
-export const UPDATE_WATERINGSCHEDULE = gql `
-    mutation($scheduleId: String!, $plants: [plantInput], $userId: String!, $timestamp: String!, $interval: Int!){
-        updateWateringSchedule(scheduleId: $scheduleId, plants: $plants, userId: $userId, timestamp: $timestamp, interval: $interval){
+export const UPDATE_WATERINGSCHEDULE = gql`
+    mutation($scheduleId: String!, $plants: [plantInput], $timestamp: String!, $interval: Int!){
+        updateWateringSchedule(scheduleId: $scheduleId, plants: $plants, timestamp: $timestamp, interval: $interval){
             id
         }
     }

--- a/client/src/views/AddWateringSchedule.vue
+++ b/client/src/views/AddWateringSchedule.vue
@@ -27,7 +27,7 @@
     <q-btn-group class="add-cancel-btn-grp">
       <q-btn label="Cancel" />
       <q-btn v-if="!scheduleToEdit" label="Add schedule" @click="addWateringSchedule" />
-      <q-btn v-if="scheduleToEdit" label="Update schedule" @click="updateWateringSchedule"/>
+      <q-btn v-if="scheduleToEdit" label="Update schedule" @click="updateWateringSchedule" />
     </q-btn-group>
   </div>
 </template>
@@ -36,8 +36,11 @@
 import { QDate, QTime, QInput, QBtnGroup, QBtn } from "quasar";
 import IncrementerButton from "../components/IncrementerButton.vue";
 import { mapGetters } from "vuex";
-import { ADD_WATERINGSCHEDULE, UPDATE_WATERINGSCHEDULE } from "../api/wateringschedule";
-import {isEmpty} from "lodash";
+import {
+  ADD_WATERINGSCHEDULE,
+  UPDATE_WATERINGSCHEDULE
+} from "../api/wateringschedule";
+import { isEmpty } from "lodash";
 
 export default {
   name: "AddWateringSchedule",
@@ -102,7 +105,6 @@ export default {
           mutation: ADD_WATERINGSCHEDULE,
           variables: {
             plants: [{ name: this.plantName }],
-            userId: this.getUserId,
             timestamp: this.timestamp.toString(),
             interval: this.calculatedInterval
           }
@@ -117,9 +119,8 @@ export default {
         await this.$apollo.mutate({
           mutation: UPDATE_WATERINGSCHEDULE,
           variables: {
-            scheduleId: this.scheduleToEdit.id, 
+            scheduleId: this.scheduleToEdit.id,
             plants: [{ name: this.plantName }],
-            userId: this.getUserId,
             timestamp: this.timestamp.toString(),
             interval: this.calculatedInterval
           }

--- a/client/src/views/MyWateringSchedules.vue
+++ b/client/src/views/MyWateringSchedules.vue
@@ -1,10 +1,6 @@
 <template>
   <ol>
-    <MyWateringScheduleCard
-      v-for="schedule in schedules"
-      :key="schedule.id"
-      :schedule="schedule"
-    />
+    <MyWateringScheduleCard v-for="schedule in schedules" :key="schedule.id" :schedule="schedule" />
   </ol>
 </template>
 
@@ -36,16 +32,13 @@ export default {
     async getMySchedules() {
       try {
         const res = await this.$apollo.query({
-          query: GET_MY_WATERINGSCHEDULES,
-          variables: {
-            userId: this.getUserId
-          }
+          query: GET_MY_WATERINGSCHEDULES
         });
         return res.data.wateringScheduleForUser;
       } catch (error) {
         alert("No schedules could be fetched, please try again later");
       }
-    },
+    }
   }
 };
 </script>

--- a/server/data-store/src/schema/index.ts
+++ b/server/data-store/src/schema/index.ts
@@ -110,7 +110,6 @@ const queryType = new GraphQLObjectType({
             description: 'The watering schedules for a user by user id',
             type: GraphQLList(WateringSchedule),
             args: {
-                userId: nonNullGqlString,
                 offset: {
                     type: GraphQLString,
                     description: 'The document id to start from.'
@@ -202,7 +201,6 @@ const mutationType = new GraphQLObjectType({
                 plants: {
                     type: GraphQLList(plantInput)
                 },
-                userId: nonNullGqlString,
                 timestamp: nonNullGqlString,
                 interval
             },
@@ -222,7 +220,6 @@ const mutationType = new GraphQLObjectType({
                 plants: {
                     type: GraphQLList(plantInput)
                 },
-                userId: nonNullGqlString,
                 timestamp: nonNullGqlString,
                 interval
             },


### PR DESCRIPTION
## **Description**

userId is no more an argument to schedule functions. Instead we take the userId from the JWT and use that instead.

## **How to test?**

Login in and create a schedule, view the list of schedules and update the one you created.
