### PR TITLE
Fix access control allow origin header

### DIFF
--- a/server/data-store/app.yaml
+++ b/server/data-store/app.yaml
@@ -2,4 +2,4 @@ runtime: nodejs12
 
 env_variables:
   FIREBASEAPIKEY: "fbapikey"
-  WHITELIST: "https://growbud-50ed4.web.app,https://growbud-50ed4.firebaseapp.com"
+  WHITELIST: "https://growbud-50ed4.appspot.com,https://growbud-50ed4.web.app,https://growbud-50ed4.firebaseapp.com"

--- a/server/data-store/src/index.ts
+++ b/server/data-store/src/index.ts
@@ -6,12 +6,14 @@ import { refreshToken as rf, RefreshInfo } from './lib/auth'
 import cookieParser from 'cookie-parser'
 const app = express()
 const port = process.env.PORT ? process.env.PORT : 9090
-const whitelist = process.env.WHITELIST
+const whitelist = process.env.WHITELIST ? process.env.WHITELIST.split(',') : []
 
 app.use(express.json())
 app.use(cookieParser())
-app.use((_req, res, next) => {
-  res.header('Access-Control-Allow-Origin', whitelist)
+app.use((req, res, next) => {
+  whitelist.forEach(host => {
+    if (req.headers.origin === host) res.header('Access-Control-Allow-Origin', req.headers.origin)
+  })
   res.header('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Accept, Authorization')
   res.header('Access-Control-Allow-Methods', 'GET, POST')
   res.header('Access-Control-Allow-Credentials', 'true')


### PR DESCRIPTION


## **Description**
The origin header may only contain one value so we have to match it with the white list.


## **How to test?**
Add different origins to the whitelist e.g http://localhost:8080 to the .env white list and try make requests with the client from those origins, against the backend. 