### PR TITLE
Fix watering schedule double read

### DIFF
--- a/server/data-store/src/lib/wateringSchedules/index.ts
+++ b/server/data-store/src/lib/wateringSchedules/index.ts
@@ -10,9 +10,9 @@ export interface WateringSchedule {
     interval: number
 }
 
-export async function getWateringSchedulesForUser(userId: string, offsetDoc: string, limit: number): Promise<Array<WateringSchedule>> {
+export async function getWateringSchedulesForUser(userId: string, offsetDoc: string | null, limit: number): Promise<Array<WateringSchedule>> {
     let snapshot: any
-    if (offsetDoc) {
+    if (typeof offsetDoc === 'string') {
         const prevSnapshot = await db.collection('wateringSchedules').doc(offsetDoc).get()
         snapshot = await db.collection('wateringSchedules')
             .where('userId', '==', userId)

--- a/server/data-store/src/schema/index.ts
+++ b/server/data-store/src/schema/index.ts
@@ -124,7 +124,7 @@ const queryType = new GraphQLObjectType({
                 return parseTokenFromHeaders(context)
                     .then(verifyAndDecodeToken)
                     .then(parseUserIdFromToken)
-                    .then(userId => getWateringSchedulesForUser(userId, args.offset, limit))
+                    .then(userId => getWateringSchedulesForUser(userId, args.offset ? args.offset : null, limit))
                     .catch(err => { console.error(err); throw new Error('Invalid Request') })
             }
         },


### PR DESCRIPTION

## **Description**
Schedule would be read twice on fetch due to the offset always being
set.

## **How to test?**
Check number of retrieves made in dev console before fetching schedules. Should not be twice the amount of fetched schedules after a get.