### PR TITLE
feat: push schedule notice

### DIFF
--- a/server/cloud-functions/functions/package.json
+++ b/server/cloud-functions/functions/package.json
@@ -16,12 +16,14 @@
   "dependencies": {
     "@google-cloud/pubsub": "^1.6.0",
     "firebase-admin": "^8.6.0",
-    "firebase-functions": "^3.3.0"
+    "firebase-functions": "^3.3.0",
+    "grpc": "^1.24.2"
   },
   "devDependencies": {
+    "@types/node": "^13.9.0",
+    "firebase-functions-test": "^0.1.6",
     "tslint": "^5.12.0",
-    "typescript": "^3.2.2",
-    "firebase-functions-test": "^0.1.6"
+    "typescript": "^3.2.2"
   },
   "private": true
 }

--- a/server/cloud-functions/functions/package.json
+++ b/server/cloud-functions/functions/package.json
@@ -14,6 +14,7 @@
   },
   "main": "lib/index.js",
   "dependencies": {
+    "@google-cloud/pubsub": "^1.6.0",
     "firebase-admin": "^8.6.0",
     "firebase-functions": "^3.3.0"
   },

--- a/server/cloud-functions/functions/src/index.ts
+++ b/server/cloud-functions/functions/src/index.ts
@@ -51,7 +51,7 @@ exports.notifySchedulesInRange = functions.region(region).https.onRequest((req, 
         logJSON('Successful update of schedules')(status)
         res.status(200).send(status)
     })
-    .cyatch((error: any) => {
+    .catch((error: any) => {
         logJSON('Error: ')(error)
         res.status(500).send({error: 'Something broke'})
     })

--- a/server/cloud-functions/functions/tsconfig.json
+++ b/server/cloud-functions/functions/tsconfig.json
@@ -11,5 +11,10 @@
   "compileOnSave": true,
   "include": [
     "src"
+  ],
+  "exclude": [
+      "node_modules",
+      "**/*.spec.ts",
+      "lib"
   ]
 }


### PR DESCRIPTION
## **Description**

<Please include a summary of the change and which issue is fixed.>
Send push notifications to registered devices when we find schedules that should be notified.
<Please also include relevant motivation and context.>
When a user has set a watering schedule they expect to be notified within a certain time every given interval. 

## **How to test?**

<Please describe the tests that you ran to verify your changes.>

<Provide instructions so we can reproduce.>

* Login on the client and enable notifications, to register a token, you might have to login again . Set a schedule for a plant.
* run:  gcloud pubsub topics publish send-push-notifications --message '{"userId":"xxxx",  "payload": {"title": "xxx", "body":"xxx" }}' to send a message.

<Please also list any relevant details for your test configuration>
<List any dependencies that are required for this change.>
