### PR TITLE
feat: 🎸 add remove schedule button in updatewateringschedule vy

### DIFF
--- a/client/src/api/wateringschedule/index.js
+++ b/client/src/api/wateringschedule/index.js
@@ -28,3 +28,11 @@ export const UPDATE_WATERINGSCHEDULE = gql`
         }
     }
 `
+
+export const DELETE_WATERINGSCHEDULE = gql`
+    mutation($scheduleId: String!){
+        deleteWateringSchedule(id: $scheduleId){
+            status
+        }
+    }
+`

--- a/client/src/views/AddWateringSchedule.vue
+++ b/client/src/views/AddWateringSchedule.vue
@@ -71,8 +71,15 @@
         >
       </div>
       <IncrementerButton class="incrementer-button" v-model="interval" />
+      
     </div>
     <div class="add-cancel-btn-grp">
+      <ui-button
+        v-if="scheduleToEdit"
+        :disabled="isFormDisabled"
+        @click="deleteWateringSchedule"
+        >Remove Schedule</ui-button
+      >
       <ui-button>Cancel</ui-button>
       <ui-button
         v-if="!scheduleToEdit"
@@ -96,7 +103,8 @@ import TimePicker from "../components/TimePicker.vue";
 import { mapGetters } from "vuex";
 import {
   ADD_WATERINGSCHEDULE,
-  UPDATE_WATERINGSCHEDULE
+  UPDATE_WATERINGSCHEDULE,
+  DELETE_WATERINGSCHEDULE
 } from "../api/wateringschedule";
 import { isEmpty } from "lodash";
 
@@ -194,6 +202,21 @@ export default {
         this.createSnackbar("Schedule Updated");
       } catch (error) {
         alert("Couldn't update schedule");
+      }
+    },
+
+    async deleteWateringSchedule() {
+      try{
+        await this.$apollo.mutate({
+          mutation: DELETE_WATERINGSCHEDULE,
+          variables:  {
+            scheduleId: this.scheduleToEdit.id
+          }
+        });
+        this.$router.push("/");
+        this.createSnackbar("Schedule Deleted");
+      } catch (error) {
+        alert("Couldn't delete schedule");
       }
     },
 


### PR DESCRIPTION
## **Description**

<Please include a summary of the change and which issue is fixed.>
A button for removing schedules has been added. It is only visible when
trying to update an existing schedule.
<Please also include relevant motivation and context.>
This enables the user to remove unwanted schedules from the UI

## **How to test?**

<Please describe the tests that you ran to verify your changes.>
I added a new wateringschedule. Went to my wateringschedules and clicked the card.
This brought me to the updatewateringschedule view which displays the remove schedule button.
Clicking it removes the schedule from my wateringschedules view (Due to a update error you have to refresh the my watering schedules view to see the changes)
<Provide instructions so we can reproduce.>

### **Steps to test**
Create watering schedule
Click the card in my watering schedules
Click the remove schedule button

### **Dependencies**
<Please also list any relevant details for your test configuration>
<List any dependencies that are required for this change.>
Run the test locally with the dev docker container