### PR TITLE
fix: 🐛 Missing module that didnt get copied to docker container

### DIFF
--- a/server/data-store/Dockerfile
+++ b/server/data-store/Dockerfile
@@ -7,6 +7,7 @@ COPY src ./src
 COPY tsconfig.json ./
 COPY .env ./
 COPY firebase_serviceAccount.json ./
+COPY express-helpers.ts ./
 
 RUN npm install
 RUN npm run tsc-build


### PR DESCRIPTION


## **Description**

<Please include a summary of the change and which issue is fixed.>
Express-helpers.ts didnt get copied to docker container in dockerfile
for server.

<Please also include relevant motivation and context.>

This PR adds the COPY command for the missing file in the dockerfile for server

## **How to test?**

<Please describe the tests that you ran to verify your changes.>
I ran docker-compose up --build and was able to build the project and login as test user
<Provide instructions so we can reproduce.>

Run docker-compose up --build and check if the project builds
<Please also list any relevant details for your test configuration>
<List any dependencies that are required for this change.>