### PR TITLE
style: 💄 Added mobilefirst styling to watering schedule cards

### DIFF
--- a/client/public/index.html
+++ b/client/public/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-    <meta name="viewport" content="width=device-width,initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width,initial-scale=1.0, user-scalable=0" />
     <link rel="icon" href="<%= BASE_URL %>favicon.ico" />
     <link
       href="https://fonts.googleapis.com/icon?family=Material+Icons"

--- a/client/src/api/wateringschedule/index.js
+++ b/client/src/api/wateringschedule/index.js
@@ -12,7 +12,7 @@ export const ADD_WATERINGSCHEDULE = gql`
 
 export const GET_MY_WATERINGSCHEDULES = gql`
     query {
-        wateringScheduleForUser {
+        schedules: wateringScheduleForUser {
             id
             plants { name }
             nextTimeToWater

--- a/client/src/components/LoggedinToolbar.vue
+++ b/client/src/components/LoggedinToolbar.vue
@@ -1,10 +1,7 @@
 <template>
   <ui-toolbar :removeNavIcon="true" title="Growbud">
     <div slot="actions">
-      <ui-button id="addSchedule primary-button" @click="goToAddWateringSchedule">
-        Add a schedule
-      </ui-button>
-      <ui-button id="mySchedules" @click="goToMyWateringSchedules">
+      <ui-button class="mySchedules navbar-button" @click="goToMyWateringSchedules">
         My schedules
       </ui-button>
     </div>
@@ -15,13 +12,6 @@ export default {
   name: "LoggedinToolbar",
 
   methods: {
-    goToAddWateringSchedule() {
-      this.$router.push("addWateringSchedule").catch(err => {
-        if (err.name !== "NavigationDuplicated") {
-          throw err;
-        }
-      });
-    },
     goToMyWateringSchedules() {
       this.$router.push("myWateringSchedules").catch(err => {
         if (err.name !== "NavigationDuplicated") {
@@ -40,13 +30,11 @@ nav {
 
 nav > div {
   padding: 10px;
-  background: linear-gradient($secondary,$primary);
+  background: linear-gradient(165deg, $primary-dark 0%, $primary 60%, $primary-light 100%);
 }
 
-#addSchedule:hover {
-  color: black;
-}
-#mySchedules:hover {
+
+.mySchedules:hover {
   color: black;
 }
 </style>

--- a/client/src/components/LoggedoutToolbar.vue
+++ b/client/src/components/LoggedoutToolbar.vue
@@ -40,7 +40,7 @@ export default {
 
 nav > div {
   padding: 10px;
-  background: linear-gradient($primary, $secondary);
+  background: linear-gradient(165deg, $primary-dark 0%, $primary 60%, $primary-light 100%);
   
 }
 </style>

--- a/client/src/components/MyWateringScheduleCard.vue
+++ b/client/src/components/MyWateringScheduleCard.vue
@@ -1,16 +1,28 @@
 <template>
-  <div class="container">
-    <div class="text-black" @click="editSchedule">
-      <div v-for="plant in schedule.plants" :key="plant.name">
+  <div class="container" @click="showExpandCard = !showExpandCard">
+    <div v-if="!showExpandCard" class="text-black" >
+      <div>Next reminder: {{ `${time} ${nextTimeToWaterAsDate.toLocaleDateString({ weekday: 'long' })} 
+        `}}</div>
+    </div>
+    <div v-else-if="showExpandCard" class="card-expanded">
+      <h3>Plants</h3>
+      <div v-for="(plant,index) in schedule.plants" :key="index" class="plant">
         {{ plant.name }}
       </div>
-      <div>{{ nextTimeToWaterAsDate }}</div>
-      <div>Interval: {{ schedule.interval }}</div>
-    </div>
+      <div class="schedule-mutation-btns">
+      <ui-button class="primary-button" @click="editSchedule">Edit</ui-button>
+      <ui-button class="removeSchedule-btn"
+        @click="deleteWateringSchedule"
+        >Remove Schedule</ui-button
+      >
+      </div>
+      </div>
+      
   </div>
 </template>
 
 <script>
+
 export default {
   name: "MyWateringScheduleCard",
   props: {
@@ -23,11 +35,14 @@ export default {
     this.nextTimeToWaterAsDate = new Date(
       parseInt(this.schedule.nextTimeToWater)
     );
+    this.formatTime([this.nextTimeToWaterAsDate.getHours(), this.nextTimeToWaterAsDate.getMinutes()])
   },
 
   data() {
     return {
-      nextTimeToWaterAsDate: ""
+      nextTimeToWaterAsDate: "",
+      time: "",
+      showExpandCard: false,
     };
   },
 
@@ -37,24 +52,73 @@ export default {
         name: "addWateringSchedule",
         params: this.schedule
       });
+    },
+
+    formatTime(time){
+      time.forEach((elem, index) => {
+        if (elem < 10) {
+        time[index] = `0${elem}`; 
+      }})
+      this.time=`${time[0]}:${time[1]}`;
+    },
+
+    deleteWateringSchedule(){
+      this.$emit("scheduleDeleted");
     }
+   
   }
 };
 </script>
 
-<style scoped>
+<style scoped lang="scss">
 .container {
   display: flex;
   justify-content: center;
-}
-.q-card {
-  width: 70%;
-  margin: 1rem;
-  display: flex;
-  flex-direction: row;
+  border-radius: 6px;
+  padding: 0.5rem;
+  box-shadow: 1px 3px 0px 0px #50aa8d;
 }
 
-.q-card__section {
-  padding: 1rem !important;
+.container:hover {
+  -webkit-box-shadow: inset 0px 0px 6px 2px #50aa8d;
+     -moz-box-shadow: inset 0px 0px 6px 2px #50aa8d;
+          box-shadow: inset 0px 0px 6px 2px #50aa8d;
+   outline: none;
 }
+
+.card-expanded{
+  width: 100%
+}
+
+h3{
+  margin: 0;
+  padding: 0 0.5rem 0.5rem;
+}
+
+.plant{
+  display: inline-block;
+  background: $primary;
+  border: 2px solid $secondary;
+  border-radius: 5px;
+  padding: 0.5rem;
+  margin: 0.2rem;
+}
+
+.schedule-mutation-btns{
+  display: flex;
+  align-items: baseline;
+
+  .removeSchedule-btn{
+    margin-top: 1rem;
+    margin-left: auto;
+    width: 40%;
+    border-radius: $standard-border-radius;
+    color:honeydew;
+    background-color: $warning !important;
+
+  }
+}
+
+
+
 </style>

--- a/client/src/components/SignupModal.vue
+++ b/client/src/components/SignupModal.vue
@@ -1,5 +1,5 @@
 <template>
-  <ui-modal ref="signupModal" @hide="onDialogHide" :title="modalTitle">
+  <ui-modal ref="signupModal" :title="modalTitle">
     <div>
       <div>
         <ui-textbox v-model="userName" outlined type="text" label="Username" />
@@ -22,16 +22,10 @@
 
 <script>
 import { REGISTER_USER } from "../api/auth";
-import { UiButton, UiTextbox, UiModal } from "keen-ui";
 
 export default {
   name: "SignupCard",
-  components: {
-    UiButton,
-    UiTextbox,
-    UiModal
-  },
-
+ 
   props: {
     showModal: {
       type: Boolean,
@@ -55,9 +49,6 @@ export default {
   },
 
   methods: {
-    onDialogHide() {
-      this.$emit("hideSignupModal", false);
-    },
 
     async register() {
       let UserObject = await this.$apollo.mutate({
@@ -76,21 +67,5 @@ export default {
 </script>
 
 <style scoped>
-.q-dialog {
-  max-width: 20rem;
-  float: right;
-}
-.q-card {
-  padding: 2rem;
-  background: cornsilk;
-}
 
-.card-title {
-  margin-bottom: 1rem;
-}
-.q-input {
-  width: 20rem;
-  margin-bottom: 1rem;
-  background-color: whitesmoke;
-}
 </style>

--- a/client/src/scss/globals.scss
+++ b/client/src/scss/globals.scss
@@ -3,13 +3,18 @@
 }
 
 .primary-button{
-  background: linear-gradient($primary, $secondary);
-  border-radius: 15px;
+  background: linear-gradient($primary, $secondary 100%);
+  border-radius: 6px;
+}
+
+.navbar-button{
+  background: linear-gradient($primary-light);
+  border-radius: 6px;
 }
 
 ::v-deep .ui-button.ui-button--type-secondary{
   background: linear-gradient(45deg,$body-cold, $body-warm);
-  border-radius: 15px;
+  border-radius: 6px;
   border-width: 2px;
   border-style: solid;
   border-color: black;

--- a/client/src/scss/variables.scss
+++ b/client/src/scss/variables.scss
@@ -1,17 +1,28 @@
-$primary: #66a842;
+$primary: #00b05d;
+$primary-light: #50aa8d;
+$primary-dark: #189b4a;
+
 $secondary: #00b05d;
 $warning: #b01700;
 
-$body-warm: #f6edd9;
-$body-cold: #f6fbf2;
+$body-warm: #2F5E4E;
+$body-cold: #50aa8d;
 
-$shade-primary: #e9c563;
-$shade-secondary: #ffd38a;
+$shade-primary: #D8FF99;
+$shade-secondary: #F4FF99;
 
-$dark: #001d00;
+$dark: #020024;
 
 $brand-primary-color: #673ab7;
 $brand-accent-color: #ff4081;
+
+
+$forest-primary: #50aa8d;
+$forest-secondary: #2F5E4E;
+
+$standard-border-radius: 6px;
+
+//#F4FF99 #EFFF99
 
 ::v-deep .ui-datepicker__display {
   height: 2.1rem;

--- a/client/src/views/AddWateringSchedule.vue
+++ b/client/src/views/AddWateringSchedule.vue
@@ -1,12 +1,5 @@
 <template>
   <div class="wrapper" @click="$emit('hide')">
-    <ui-button class="removeSchedule-btn"
-        v-if="scheduleToEdit"
-        :disabled="isFormDisabled"
-        @click="deleteWateringSchedule"
-        >Remove Schedule</ui-button
-      >
-      
     <div class="plants">
       <div class="plantInput">
         <input
@@ -108,7 +101,6 @@ import { mapGetters } from "vuex";
 import {
   ADD_WATERINGSCHEDULE,
   UPDATE_WATERINGSCHEDULE,
-  DELETE_WATERINGSCHEDULE
 } from "../api/wateringschedule";
 import { isEmpty } from "lodash";
 
@@ -206,21 +198,6 @@ export default {
         this.createSnackbar("Schedule Updated");
       } catch (error) {
         alert("Couldn't update schedule");
-      }
-    },
-
-    async deleteWateringSchedule() {
-      try{
-        await this.$apollo.mutate({
-          mutation: DELETE_WATERINGSCHEDULE,
-          variables:  {
-            scheduleId: this.scheduleToEdit.id
-          }
-        });
-        this.$router.push("/");
-        this.createSnackbar("Schedule Deleted");
-      } catch (error) {
-        alert("Couldn't delete schedule");
       }
     },
 
@@ -346,8 +323,8 @@ export default {
   li {
     display: flex;
     align-items: center;
-    border: 1px solid;
-    background: $secondary;
+    background: $primary;
+    border: 2px solid $secondary;
     border-radius: 5px;
     padding: 0.25rem;
     margin: 0.1rem;
@@ -417,15 +394,6 @@ export default {
   position: absolute;
   bottom: 1rem;
   width: 100%;
-}
-
-.removeSchedule-btn{
-  margin-top: 1rem;
-  margin-left: auto;
-  width: 40%;
-  border-radius: 15px;
-  background-color: $warning !important;
-
 }
 
 


### PR DESCRIPTION


## **Description**

<Please include a summary of the change and which issue is fixed.>

MyWateringSchedules view has been redesigned for mobile first.
I have also updated the color scheme of the app after inspiration from https://www.forestapp.cc/
I really liked to combination of colors used and felt that it would fit the look I was going for.

This PR doesnt only contain styling. In my eagerness I fixed some other issues as well.
You can now click a card and it will be expanded. The expanded view gives you the options to view Which plants are in the schedule and an Edit and Delete button for the schedule.

<Please also include relevant motivation and context.>

## **How to test?**

<Please describe the tests that you ran to verify your changes.>
I added a couple of schedules. These will then show up under MyWateringSchedules

Click a card to expand it.
Verify that all button are clickable and does what they say.
<Provide instructions so we can reproduce.>
<Please also list any relevant details for your test configuration>
<List any dependencies that are required for this change.>
