### PR TITLE
fix: 🐛 Wait till store is initialized before calling graphql

### DIFF
--- a/client/src/main.js
+++ b/client/src/main.js
@@ -54,14 +54,17 @@ const apolloProvider = new VueApollo({
 
 Vue.config.productionTip = false
 
-if(store.getters.getUserId === "") {
-  store.dispatch('persistLogin');
-}
-
 window.setInterval(function () {
   store.dispatch('silentTokenRefresh');
 }, 360000);
 
+router.beforeEach((to,from,next) => {
+  if(!store.getters.getJWT.length){
+    store.dispatch('persistLogin').then(() => next())
+  }else{
+    next();
+  }
+})
 
 new Vue({
   router,

--- a/client/src/store.js
+++ b/client/src/store.js
@@ -32,8 +32,8 @@ export default new Vuex.Store({
   },
 
   getters: {
-    getUserId: state => {
-      return state.userID;
+    getJWT: state => {
+      return state.inMemoryToken.JWT;
     },
     isLoggedin: state => {
       return state.isLoggedin;
@@ -42,22 +42,25 @@ export default new Vuex.Store({
 
   actions: {
 
-    persistLogin(context){
-      refreshToken().then((response) => {
+    async persistLogin(context){
+      try{
+      const response = await refreshToken()
 
-        const {
-          JWT,
-          JWTExpiry
-        } = response.data;
+      const {
+        JWT,
+        JWTExpiry
+      } = response.data;
 
-        context.commit('setInMemoryToken', {
-          JWT,
-          JWTExpiry
-        });
+      context.commit('setInMemoryToken', {
+        JWT,
+        JWTExpiry
+      });
         
-        context.commit('setIsLoggedin', true)
-    })
-  },
+      context.commit('setIsLoggedin', true)
+    }catch(e){
+      console.error(e) //eslint-disable-line
+    }
+    },
 
     silentTokenRefresh(context) { //eslint-disable-line
       if (!this.state.inMemoryToken.JWT) {

--- a/client/src/views/AddWateringSchedule.vue
+++ b/client/src/views/AddWateringSchedule.vue
@@ -97,7 +97,6 @@
 <script>
 import IncrementerButton from "../components/IncrementerButton.vue";
 import TimePicker from "../components/TimePicker.vue";
-import { mapGetters } from "vuex";
 import {
   ADD_WATERINGSCHEDULE,
   UPDATE_WATERINGSCHEDULE,
@@ -141,7 +140,6 @@ export default {
   },
 
   computed: {
-    ...mapGetters(["getUserId"]),
 
     timestamp() {
       if (this.time.length) {

--- a/client/src/views/MyWateringSchedules.vue
+++ b/client/src/views/MyWateringSchedules.vue
@@ -3,7 +3,8 @@
      <ui-button class="addSchedule-btn primary-button" @click="goToAddWateringSchedule">
         Add a schedule
       </ui-button>
-    <ul style="list-style:none;" v-if="schedules.length && !$apollo.loading">
+    <div v-if="!$apollo.loading">
+    <ul style="list-style:none;" v-if="schedules.length">
       <MyWateringScheduleCard 
         class="card"
         v-for="schedule in schedules"
@@ -13,6 +14,9 @@
       />
     </ul>
     <div>{{ schedules.length }}</div>
+    </div>
+  <ui-progress-circular v-else></ui-progress-circular>
+    
   </div>
 </template>
 
@@ -27,12 +31,16 @@ export default {
     MyWateringScheduleCard
   },
 
-   apollo: {
+  apollo:{
     schedules: {
       query: GET_MY_WATERINGSCHEDULES,
     }
   },
 
+  created(){
+    
+    this.$apollo.queries.schedules.refetch();
+  },
 
   data() {
     return {
@@ -41,7 +49,7 @@ export default {
   },
   
   computed: {
-    ...mapGetters(["getUserId", "isLoggedin"]),
+    ...mapGetters(["isLoggedin"]),
   },
 
   methods:{


### PR DESCRIPTION
## **Description**

<Please include a summary of the change and which issue is fixed.>
We had a bug were the Client couldn't fetch data from backend because the fetch was sent before the store had the JWT.

<Please also include relevant motivation and context.>

Before each router navigation we check for the JWT and we wait for the response before we let the user continue with navigation.

## **How to test?**

<Please describe the tests that you ran to verify your changes.>
Login -> go to myWateringSchedules and verify that the schedules are loaded even when refreshing.
<Provide instructions so we can reproduce.>

Test the following and make sure the UI updates in between each action: 
 -Add new schedule 
 -Update schedule 
 -Delete schedule 

<Please also list any relevant details for your test configuration>
<List any dependencies that are required for this change.>
